### PR TITLE
Bug-fix: Parsing names from Google Play Store breaks when the name is not a version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.1.0+4
+
+* Bug-fix: Parsing names from Google Play Store breaks when the name is not a version.
+
 ## 0.1.0+3
 
-* Bug-fix: bad RegExp in for private key
+* Bug-fix: bad RegExp in for private key.
 * Bug-fix: Missing output directory in `google-play-version` command.
 * Bug-fix: Missing output directory in `app-store-version` command.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
 
-## 0.1.0-beta+5
+## 0.1.0+7
 
-* Updated app_store_connect_version to 0.1.0+1
+* Now using the android version code from the google play console.
+
+## 0.1.0-beta+7
+
+* Bug-fix: Using the android version code to generate the version name.
+
+## 0.1.0-beta+6
+
+* Using the android version code to generate the version name.
+
+## 0.1.0+5
+
+* Updated app_store_connect_version to 0.1.0+1.
 
 ## 0.1.0+4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0-beta+5
+
+* Updated app_store_connect_version to 0.1.0+1
+
 ## 0.1.0+4
 
 * Bug-fix: Parsing names from Google Play Store breaks when the name is not a version.

--- a/README.md
+++ b/README.md
@@ -26,25 +26,15 @@ Check the latest version of your app on Google Play (includes internal testing) 
 Note: see [here](https://developers.google.com/workspace/guides/create-credentials#service-account) for more information on how to get your Google Service Account credentials.
 
 ```sh
-Gets the latest version of the app from the Google Play Store.
+Gets the latest version code of the app from the Google Play Console.
 
-Usage: automatic_version_upgrader google-play-version
--h, --help                                       Print this usage information.
--p, --package-name (mandatory)                   The package name of the app.
-    --credentials                                The credentials for the Google Cloud Service Account.
-    --next=<major|minor|patch|breaking|build>    Updates the version number.
+Usage: automatic_version_upgrader google-play-version-code
+-h, --help                        Print this usage information.
+-p, --package-name (mandatory)    The package name of the app.
+    --credentials                 The credentials for the Google Cloud Service Account.
+-u, --[no-]upgrade                Updates the Android app's version code to the oldest plus one.
 
-          [breaking]                             Gets the next breaking version number that follows this one. Increments [major] if it is greater than zero, otherwise [minor], resets subsequent digits to zero, and strips any [preRelease] or [build] suffix.
-          [build] (default)                      Gets the next build number that follows this one. If this version is a pre-release, then it just strips the pre-release suffix. Otherwise, it increments the build. Note: If the latest version is actually bigger than the latest build, then the build number is reset to zero and the version grabbed will be the next patch to the latest version.
-          [major]                                Gets the next major version number that follows this one. If this version is a pre-release of a major version release (i.e. the minor and patch versions are zero), then it just strips the pre-release suffix. Otherwise, it increments the major version and resets the minor and patch.
-          [minor]                                Gets the next minor version number that follows this one. If this version is a pre-release of a minor version release (i.e. the patch version is zero), then it just strips the pre-release suffix. Otherwise, it increments the minor version and resets the patch.
-          [patch]                                Gets the next patch version number that follows this one. If this version is a pre-release, then it just strips the pre-release suffix. Otherwise, it increments the patch version.
-
--u, --upgrade-mode=<always|never|outdated>       Updates the version in your app's pubspec.yaml file.
-
-          [always]                               Updates the app's version to the newest and ups the patch number.
-          [never] (default)                      Doesn't update the version.
-          [outdated]                             Updates the app's version if there's a newer one available. Otherwise, does nothing.
+Run "automatic_version_upgrader help" to see global options.
 ```
 
 #### Usage
@@ -54,10 +44,7 @@ Usage: automatic_version_upgrader google-play-version
 automatic_version_upgrader google-play-version --package-name=com.maps.google  --credentials=[the contents of your credentials.json file] 
 
 # Updates the app's version to the newest and ups the patch number.
-automatic_version_upgrader google-play-version --package-name=com.maps.google  --credentials=[the contents of your credentials.json file] --upgrade-mode=outdated
-
-# Updates the app's version to the newest and ups the major number.
-automatic_version_upgrader google-play-version --package-name=com.maps.google  --credentials=[the contents of your credentials.json file] --upgrade-mode=outdated --next=major
+automatic_version_upgrader google-play-version --package-name=com.maps.google  --credentials=[the contents of your credentials.json file] -u
 ```
 
 
@@ -100,10 +87,10 @@ Run "automatic_version_upgrader help" to see global options.
 automatic_version_upgrader app-store-version --app-id=[your app id] --private-key=[your private key] key-id=[your key id] --issuer-id=[your issuer id] 
 
 # Updates the app's version to the newest and ups the patch number.
-automatic_version_upgrader google-play-version --app-id=[your app id] --private-key=[your private key] key-id=[your key id] --issuer-id=[your issuer id] --upgrade-mode=outdated
+automatic_version_upgrader app-store-version --app-id=[your app id] --private-key=[your private key] key-id=[your key id] --issuer-id=[your issuer id] --upgrade-mode=outdated
 
 # Updates the app's version to the newest and ups the major number.
-automatic_version_upgrader google-play-version --app-id=[your app id] --private-key=[your private key] key-id=[your key id] --issuer-id=[your issuer id] --upgrade-mode=outdated --next=major
+automatic_version_upgrader app-store-version --app-id=[your app id] --private-key=[your private key] key-id=[your key id] --issuer-id=[your issuer id] --upgrade-mode=outdated --next=major
 ```
 
 ### `automatic_version_upgrader --help`
@@ -126,10 +113,10 @@ Global options:
     --[no-]verbose    Noisy logging, including all shell commands executed.
 
 Available commands:
-  app-store-version     Gets the latest version of the app from the App Store.
-  google-play-version   automatic_version_upgrader google-play-version
-                        Gets the latest version of the app from the Google Play Store.
-  update                Update Automatic Version Upgrader CLI.
+  app-store-version          Gets the latest version of the app from the App Store.
+  google-play-version-code   automatic_version_upgrader google-play-version-code
+                             Gets the latest version code of the app from the Google Play Console.
+  update                     Update Automatic Version Upgrader CLI.
 
 Run "automatic_version_upgrader help <command>" for more information about a command.
 ```

--- a/lib/automatic_version_upgrader.dart
+++ b/lib/automatic_version_upgrader.dart
@@ -7,3 +7,4 @@ library automatic_version_upgrader;
 export 'src/command_runner.dart';
 export 'src/commands/commands.dart';
 export 'src/extensions/extensions.dart';
+export 'src/helpers/helpers.dart';

--- a/lib/src/commands/app_store_version.dart
+++ b/lib/src/commands/app_store_version.dart
@@ -219,8 +219,10 @@ class AppStoreVersionCommand extends Command<int> {
     }
 
     try {
-      final updatedPubspc = pubspec.copy(version: nextVersion);
-      await updatedPubspc.save(_outputDirectory);
+      PubspecVersionChanger(logger: _logger).updateVersionCode(
+        _outputDirectory,
+        nextVersion.toString(),
+      );
 
       versionUpgradingProgress.complete();
       _logger.success('The app version has been upgraded to $nextVersion.');

--- a/lib/src/extensions/google_play_last_version.dart
+++ b/lib/src/extensions/google_play_last_version.dart
@@ -1,82 +1,51 @@
-import 'package:automatic_version_upgrader/src/extensions/extensions.dart';
 import 'package:googleapis/androidpublisher/v3.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 /// Returns the latest version available in the response.
 extension LatestVersion on TracksListResponse {
-  /// Returns the latest version available in the response.
-  Version get latestVersion => tracks?.latestVersion ?? Version.none;
+  /// Returns the latest version code available in the response.
+  int get latestVersionCode => tracks?.latestVersionCode ?? 1;
 }
 
-/// Returns the latest version of the tracks available.
+/// Returns the latest version code of the tracks available.
 extension LatestTrackVersion on List<Track>? {
-  /// Returns the latest version of the tracks available.
-  Version get latestVersion {
-    final strippedToVersion = <Version, Version>{};
+  /// Returns the latest code version of the tracks available.
+  int get latestVersionCode {
+    final versionCodes = <int>[];
 
     this?.forEach((element) {
-      strippedToVersion.addAll({
-        element.releases.latestVersion.stripPreRelease():
-            element.releases.latestVersion,
-      });
-    });
-
-    final version = Version.primary(strippedToVersion.keys.toList());
-    return strippedToVersion[version]!;
-  }
-}
-
-/// Returns the latest version of the tracks available.
-extension LatestTrackReleaseVersion on List<TrackRelease>? {
-  /// Returns the latest version of the app.
-  Version get latestVersion {
-    final strippedToVersion = <Version, Version>{};
-
-    this?.forEach((element) {
-      final name = element.name ?? Version.none.toString();
-      final buildList = (element.versionCodes ?? []).map(int.parse).toList()
-        ..sort();
-
-      var latestBuildNumber = 0;
-      try {
-        latestBuildNumber = buildList.last;
-      } catch (_) {}
-
-      if (name.contains('(')) {
-        final versionStr = name.substring(
-          name.indexOf('(') + 1,
-          name.indexOf(')'),
-        );
-
-        if (versionStr.isNotEmpty) {
-          try {
-            final version = Version.parse(versionStr).copy(
-              build: latestBuildNumber.toString(),
-            );
-
-            strippedToVersion.addAll({
-              version.stripPreRelease(): version,
-            });
-          } catch (_) {}
-        }
-      } else {
-        try {
-          final version = Version.parse(name).copy(
-            build: latestBuildNumber.toString(),
-          );
-
-          strippedToVersion.addAll({
-            version.stripPreRelease(): version,
-          });
-        } catch (_) {}
+      final versionCode = element.releases?.latestVersionCode;
+      if (versionCode != null) {
+        versionCodes.add(versionCode);
       }
     });
 
-    if (strippedToVersion.isEmpty) {
-      return Version.none;
+    versionCodes.sort();
+    try {
+      return versionCodes.last;
+    } catch (_) {
+      return 0;
     }
+  }
+}
 
-    final primary = Version.primary(strippedToVersion.keys.toList());
-    return strippedToVersion[primary] ?? Version.none;
+/// Returns the latest version code of the tracks available.
+extension LatestTrackReleaseVersion on List<TrackRelease>? {
+  /// Returns the latest version code of the app.
+  int get latestVersionCode {
+    final versionCodes = <int>{};
+
+    this?.forEach((element) {
+      final buildList = (element.versionCodes ?? []).map(int.parse).toList()
+        ..sort();
+      try {
+        versionCodes.add(buildList.last);
+      } catch (_) {}
+    });
+
+    try {
+      return versionCodes.last;
+    } catch (_) {
+      return 0;
+    }
   }
 }

--- a/lib/src/extensions/google_play_last_version.dart
+++ b/lib/src/extensions/google_play_last_version.dart
@@ -49,24 +49,32 @@ extension LatestTrackReleaseVersion on List<TrackRelease>? {
         );
 
         if (versionStr.isNotEmpty) {
-          final version = Version.parse(versionStr).copy(
+          try {
+            final version = Version.parse(versionStr).copy(
+              build: latestBuildNumber.toString(),
+            );
+
+            strippedToVersion.addAll({
+              version.stripPreRelease(): version,
+            });
+          } catch (_) {}
+        }
+      } else {
+        try {
+          final version = Version.parse(name).copy(
             build: latestBuildNumber.toString(),
           );
 
           strippedToVersion.addAll({
             version.stripPreRelease(): version,
           });
-        }
-      } else {
-        final version = Version.parse(name).copy(
-          build: latestBuildNumber.toString(),
-        );
-
-        strippedToVersion.addAll({
-          version.stripPreRelease(): version,
-        });
+        } catch (_) {}
       }
     });
+
+    if (strippedToVersion.isEmpty) {
+      return Version.none;
+    }
 
     final primary = Version.primary(strippedToVersion.keys.toList());
     return strippedToVersion[primary] ?? Version.none;

--- a/lib/src/helpers/change_pubspec_version.dart
+++ b/lib/src/helpers/change_pubspec_version.dart
@@ -1,0 +1,51 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:universal_io/io.dart';
+
+/// {@template pubspec_version_changer_template}
+/// The [PubspecVersionChanger] class is used to change the version code of the
+/// and version name in a pubspec.yaml file.
+class PubspecVersionChanger {
+  /// {@macro pubspec_version_changer_template}
+  PubspecVersionChanger({
+    Logger? logger,
+  }) : _logger = logger ?? Logger();
+
+  final Logger _logger;
+  final _pubspecFile = File('pubspec.yaml');
+
+  /// Updates the version of the pubspec.yaml file.
+  void updateVersionCode(
+    Directory pubspecRoot,
+    String newVersion,
+  ) {
+    if (!_pubspecFile.existsSync()) {
+      _logger.err('pubspec.yaml not found');
+      exit(ExitCode.osFile.code);
+    }
+
+    final pubspecLines = _pubspecFile.readAsLinesSync();
+
+    final pubspecVersionLine = pubspecLines.asMap().entries.firstWhere(
+          (element) => element.value.startsWith('version:'),
+        );
+
+    final _newVersion = Version.parse(newVersion);
+
+    pubspecLines[pubspecVersionLine.key] = 'version: $_newVersion';
+    _pubspecFile.writeAsStringSync(pubspecLines.join('\n'));
+  }
+
+  /// Gets the current version of the pubspec.yaml file.
+  Version currentVersion(
+    Directory pubspecRoot,
+  ) {
+    final pubspecLines = _pubspecFile.readAsLinesSync();
+    final pubspecVersionLine = pubspecLines.asMap().entries.firstWhere(
+          (element) => element.value.startsWith('version:'),
+        );
+    final currentVersionStr =
+        pubspecVersionLine.value.substring('version:'.length).trim();
+    return Version.parse(currentVersionStr);
+  }
+}

--- a/lib/src/helpers/helpers.dart
+++ b/lib/src/helpers/helpers.dart
@@ -1,0 +1,1 @@
+export 'change_pubspec_version.dart';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.0+4';
+const packageVersion = '0.1.0-beta+5';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.0-beta+5';
+const packageVersion = '0.1.0+7';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.0+3';
+const packageVersion = '0.1.0+4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: automatic_version_upgrader
-version: 0.1.0+3
+version: 0.1.0+4
 description: A command line interface to upgrade your app version automatically in a CI/CD flow.
 homepage: https://github.com/tomassasovsky/automatic_version_upgrader.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: automatic_version_upgrader
-version: 0.1.0+4
+version: 0.1.0-beta+5
 description: A command line interface to upgrade your app version automatically in a CI/CD flow.
 homepage: https://github.com/tomassasovsky/automatic_version_upgrader.dart
 
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  app_store_connect_app_versions: ^0.1.0
+  app_store_connect_app_versions: ^0.1.0+1
   args: ^2.3.1
   equatable: ^2.0.3
   googleapis: ^9.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: automatic_version_upgrader
-version: 0.1.0-beta+5
+version: 0.1.0+7
 description: A command line interface to upgrade your app version automatically in a CI/CD flow.
 homepage: https://github.com/tomassasovsky/automatic_version_upgrader.dart
 
@@ -12,6 +12,7 @@ dependencies:
   equatable: ^2.0.3
   googleapis: ^9.1.0
   googleapis_auth: ^1.3.1
+  gradle_properties: ^1.0.0
   http: ^0.13.5
   mason_logger: ^0.1.1
   meta: ^1.8.0


### PR DESCRIPTION
## Description

Bug-fix: Parsing names from Google Play Store breaks when the name is not a version.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
